### PR TITLE
chore: clean up reset password page

### DIFF
--- a/src/pages/ResetPasswordPage.tsx
+++ b/src/pages/ResetPasswordPage.tsx
@@ -1,116 +1,9 @@
-// // src/pages/ResetPasswordPage.js
-// import React, { useState } from 'react';
-// import { useSearchParams, } from 'react-router-dom';
-// import { gql, useMutation } from '@apollo/client';
-// import { Label } from "../components/ui/label";
-// // import { Input } from "../components/ui/input";
-// import { cn } from "@/lib/utils";
-// import { PasswordInput } from '@/components/ui/password-input';
-// const RESET_PASSWORD = gql`
-//   mutation ResetPassword($token: String!, $password: String!) {
-//     resetPassword(token: $token, password: $password)
-//   }
-// `;
-
-// export default function ResetPasswordPage() {
-//   const [searchParams] = useSearchParams();
-//   const token = searchParams.get('token') || '';
-//   const [password, setPassword] = useState('');
-//   const [confirmPassword, setConfirmPassword] = useState('');
-//   const [resetPassword, { loading }] = useMutation(RESET_PASSWORD);
-
-//   const [usermsg, setUserMsg] = useState({
-//     type: '',
-//     message: '',
-//   });
-//   const handleSubmit = async (e: { preventDefault: () => void; }) => {
-//     e.preventDefault();
-//     console.log("Password:", password);
-//     console.log("Confirm Password:", confirmPassword);
-//     if (password !== confirmPassword) {
-
-//       setUserMsg({ type: "error", message: "Passwords do not match!" });
-//       return;
-//     }
-//      resetPassword({ variables: { token, password } })
-//       .then((res) => {
-//        console.log(res);
-//        setUserMsg({ type: "success", message: res.data.resetPassword });
-//      })
-//       .catch((err) => {
-//         console.log(err.networkError.result.errors[0].message);
-//         // setUserMsg({ type: "error", message: err.networkError });
-//       });
-
-  
-
-//   };
-
-//   return (
-//     <div className="flex flex-col w-full min-w-full  justify-center min-h-screen p-4 bg-gray-100">
-//       <h2 className='text-center text-2xl my-4 font-bold'>Reset Password</h2>
-    
-//         <form onSubmit={handleSubmit}>
-// {usermsg.message && (
-//   <div
-//     className={`${
-//       usermsg.type === 'success'
-//         ? 'bg-green-500'
-//         : 'bg-red-500'
-//     } text-white px-4 py-2 rounded-md mb-4`}
-//   >
-//     {usermsg.message}
-//   </div>
-// )}
-//                   <LabelInputContainer className="mb-4">
-//           <Label htmlFor="password">Password</Label>
-//           <PasswordInput id="password" placeholder="••••••••"             
-//            value={password}
-//             onChange={e => setPassword(e.target.value)}
-//             required/>
-//         </LabelInputContainer>
-//         <LabelInputContainer className="mb-8">
-//           <Label htmlFor="twitterpassword">Confirm Password</Label>
-//           <PasswordInput
-//           value={confirmPassword}
-//             onChange={e => setConfirmPassword(e.target.value)}
-//             required
-//             id="twitterpassword"
-//             placeholder="••••••••"
-            
-//           />
-//         </LabelInputContainer>
-//           <button type="submit" disabled={loading} className="group/btn relative block h-10 w-full rounded-md bg-gradient-to-br from-black to-neutral-600 font-medium text-white shadow-[0px_1px_0px_0px_#ffffff40_inset,0px_-1px_0px_0px_#ffffff40_inset] dark:bg-zinc-800 dark:from-zinc-900 dark:to-zinc-900 dark:shadow-[0px_1px_0px_0px_#27272a_inset,0px_-1px_0px_0px_#27272a_inset]">
-//             {loading ? 'Resetting…' : 'Reset Password'}
-//           </button>
-//         </form>
-//     </div>
-//   );
-// }
-
-
-// const LabelInputContainer = ({
-//   children,
-//   className,
-// }: {
-//   children: React.ReactNode;
-//   className?: string;
-// }) => {
-//   return (
-//     <div className={cn("flex w-full flex-col space-y-2", className)}>
-//       {children}
-//     </div>
-//   );
-// };
-
-// src/pages/ResetPasswordPage.js
 import React, { useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
-import { gql, useMutation } from '@apollo/client';
+import { gql, useMutation, isApolloError } from '@apollo/client';
 import { Label } from '../components/ui/label';
 import { PasswordInput } from '@/components/ui/password-input';
 import { cn } from '@/lib/utils';
-import {  isApolloError } from '@apollo/client';
 const RESET_PASSWORD = gql`
   mutation ResetPassword($token: String!, $password: String!) {
     resetPassword(token: $token, password: $password) {
@@ -168,29 +61,28 @@ export default function ResetPasswordPage() {
           message: firstError?.message ?? 'Unable to reset password.',
         });
       }
-    } catch (error:  unknown) {
+    } catch (error: unknown) {
       console.error('Reset password error', error);
-     // Narrow the unknown to an ApolloError
-     if (isApolloError(error as Error)) {
-       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-       const gqlErr = (error as Error & { graphQLErrors?: any[] }).graphQLErrors?.[0];
-       // Our interceptor stored the full envelope in extensions
-       const ext = gqlErr.extensions as {
-         success: boolean;
-         errors: Array<{ field: string; message: string }>;
-         data: null;
-       } | undefined;
-       const msg =
-         ext?.errors?.[0]?.message  // our custom error string
-         ?? gqlErr.message          // fallback GraphQLError message
-         ?? 'Unable to reset password.';
-       setUserMsg({ type: 'error', message: msg });
-     } else {
-       setUserMsg({
-         type: 'error',
-         message: 'Something went wrong. Please try again.',
-       });
-     }
+      // Narrow the unknown to an ApolloError
+      if (isApolloError(error)) {
+        const gqlErr = error.graphQLErrors[0];
+        // Our interceptor stored the full envelope in extensions
+        const ext = gqlErr?.extensions as {
+          success: boolean;
+          errors: Array<{ field: string; message: string }>;
+          data: null;
+        } | undefined;
+        const msg =
+          ext?.errors?.[0]?.message // our custom error string
+          ?? gqlErr?.message // fallback GraphQLError message
+          ?? 'Unable to reset password.';
+        setUserMsg({ type: 'error', message: msg });
+      } else {
+        setUserMsg({
+          type: 'error',
+          message: 'Something went wrong. Please try again.',
+        });
+      }
     }
   };
 


### PR DESCRIPTION
## Summary
- remove obsolete commented block in ResetPasswordPage
- simplify error handling by using isApolloError without casts

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68918538b86c8324ad6e1178f0bf6e46