### PR TITLE
Refactor email verification effect and remove logging

### DIFF
--- a/src/pages/VerifyEmailPage.tsx
+++ b/src/pages/VerifyEmailPage.tsx
@@ -45,28 +45,32 @@ export default function VerifyEmailPage() {
   const [showRequestNewVerification, setShowRequestNewVerification] =
     useState(false);
   useEffect(() => {
-    verifyEmail({ variables: { token } })
-      .then((res) => {
-        console.log(res);
+    async function verify() {
+      try {
+        const res = await verifyEmail({ variables: { token } });
         setMessage(res.data.message.verifyEmail);
-      })
-      .catch((err) => setMessage(err.message));
-  }, [token]);
+      } catch (err) {
+        if (err instanceof Error) {
+          setMessage(err.message);
+        } else {
+          setMessage(String(err));
+        }
+      }
+    }
+    verify();
+  }, [verifyEmail, token]);
 
   const handleRequestNewVerification = () => {
     setMessage("");
     setShowRequestNewVerification(true);
     resendVerificationEmail({ variables: { token } })
       .then((res) => {
-        console.log(res);
         setMessage(res.data.message.resendVerificationEmail);
       })
       .catch((err) => {
-        console.log(err);
         setMessage(err.message);
       });
   };
-console.log(message);
   return (
     <div className="flex flex-col items-center justify-start min-h-screen p-4 bg-gray-100">
       {showRequestNewVerification ? (


### PR DESCRIPTION
## Summary
- wrap verification call in an async function and include `verifyEmail` and `token` in useEffect deps
- strip console.log statements from verification flows

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6891850990388324b8f729dd456a859f