### PR TITLE
Use correct password input type in signup form

### DIFF
--- a/src/components/signup-form-demo.tsx
+++ b/src/components/signup-form-demo.tsx
@@ -48,7 +48,7 @@ export default function SignupFormDemo() {
           <Input
             id="twitterpassword"
             placeholder="••••••••"
-            type="twitterpassword"
+            type="password"
           />
         </LabelInputContainer>
 


### PR DESCRIPTION
## Summary
- use `password` type for twitter password field

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689184fafaa88324a52bfbfcdbac6f8f